### PR TITLE
fix: support anchor mode in vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is Casdoor's SDK for js will allow you to easily connect your application t
 without having to implement it from scratch.
 
 Casdoor SDK is very simple to use. We will show you the steps below.
-
+ 
 > Noted that this sdk has been applied to casnode, if you still don’t know how to use it after reading README.md, you can refer to it
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ without having to implement it from scratch.
 Casdoor SDK is very simple to use. We will show you the steps below.
  
 > Noted that this sdk has been applied to casnode, if you still don’t know how to use it after reading README.md, you can refer to it
-
+ 
 ## Installation
 
 ~~~shell script

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [download-image]: https://img.shields.io/npm/dm/casdoor-vue-sdk.svg?style=flat-square
 
 [download-url]: https://npmjs.com/package/casdoor-vue-sdk
-
+ 
 This is Casdoor's SDK for js will allow you to easily connect your application to the Casdoor authentication system
 without having to implement it from scratch.
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@
 [download-image]: https://img.shields.io/npm/dm/casdoor-vue-sdk.svg?style=flat-square
 
 [download-url]: https://npmjs.com/package/casdoor-vue-sdk
- 
+
 This is Casdoor's SDK for js will allow you to easily connect your application to the Casdoor authentication system
 without having to implement it from scratch.
 
 Casdoor SDK is very simple to use. We will show you the steps below.
- 
+
 > Noted that this sdk has been applied to casnode, if you still don’t know how to use it after reading README.md, you can refer to it
- 
+
 ## Installation
 
 ~~~shell script

--- a/src/CasdoorSDK.js
+++ b/src/CasdoorSDK.js
@@ -57,7 +57,12 @@ export default {
       };
 
       app.config.globalProperties.signin = (ServerUrl) => {
-        return CasdoorSDK.signin(ServerUrl);
+        const code = window.location.href.split('code=')[1].split('&')[0];
+        const state = window.location.href.split('state=')[1].split('&')[0];
+        return fetch(`${ServerUrl}/api/signin?code=${code}&state=${state}`, {
+          method: "POST",
+          credentials: "include",
+        }).then(res => res.json());
       };
     }
 


### PR DESCRIPTION
In casdoor-js-sdk,this method↓ of getting the params will fail in vue anchor mode:
![image](https://user-images.githubusercontent.com/75596353/165946164-ad9d80e5-8e27-4d15-a657-cc2efb3f9156.png)
Because "?code=..." isn't considered the query string in your case.It's part of the anchor (#) ,So the window.location.search will get null.
To fix it,I Reimplement it independently in vue-sdk.