### PR TITLE
feat: Add provide/inject method

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,34 @@ export default {
 </script>
 ```
 
+If you are using vue3 composition API, since it is inconvenient to obtain the Vue instance in `setup()`, `useCasdoor` provided a better way to access the sdk's methods.
+
+```vue
+<script>
+import { useCasdoor } from 'casdoor-vue-sdk';
+
+export default {
+  setup() {
+
+    const { getSigninUrl, getSignupUrl } = useCasdoor();
+
+    function login() {
+      window.location.href = getSigninUrl();
+    }
+
+    function signup() {
+      window.location.href = getSignupUrl();
+    }
+
+    return {
+      login,
+      signup
+    }
+  }
+}
+</script>
+```
+
 ## Q & A
 
 Q1:  How to solve "...index.js implicitly has an 'any' type..." error in typescript project?

--- a/index.js
+++ b/index.js
@@ -12,6 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Casdoor from './src/CasdoorSDK'
+import { inject } from 'vue'
+import Sdk from 'casdoor-js-sdk';
+import { CASDOOR_SDK_INJECTION_KEY } from '@/token'
+import Casdoor from '@/CasdoorSDK'
 
 export default Casdoor
+
+/**
+ * @summary returns the instance of `Sdk`. 
+ * @returns {Sdk}
+ */
+export function useCasdoor() {
+    return inject(CASDOOR_SDK_INJECTION_KEY);
+}

--- a/src/CasdoorSDK.js
+++ b/src/CasdoorSDK.js
@@ -42,7 +42,15 @@ export default {
       };
     }else{
 
-      app.provide(CASDOOR_SDK_INJECTION_KEY,CasdoorSDK);
+      app.provide(CASDOOR_SDK_INJECTION_KEY,
+        {
+          getSignupUrl: CasdoorSDK.getSignupUrl.bind(CasdoorSDK),
+          getSigninUrl: CasdoorSDK.getSigninUrl.bind(CasdoorSDK),
+          getUserProfileUrl: CasdoorSDK.getUserProfileUrl.bind(CasdoorSDK),
+          getMyProfileUrl: CasdoorSDK.getMyProfileUrl.bind(CasdoorSDK),
+          signin: CasdoorSDK.signin.bind(CasdoorSDK)
+        }
+      );
 
       app.config.globalProperties.getSignupUrl = () => {
         return CasdoorSDK.getSignupUrl();

--- a/src/CasdoorSDK.js
+++ b/src/CasdoorSDK.js
@@ -14,6 +14,7 @@
 
 import Sdk from "casdoor-js-sdk";
 import {isVue2} from "vue-demi";
+import { CASDOOR_SDK_INJECTION_KEY } from "@/token";
 
 export default {
   install(app, options) {
@@ -40,6 +41,9 @@ export default {
         return CasdoorSDK.signin(ServerUrl);
       };
     }else{
+
+      app.provide(CASDOOR_SDK_INJECTION_KEY,CasdoorSDK);
+
       app.config.globalProperties.getSignupUrl = () => {
         return CasdoorSDK.getSignupUrl();
       };

--- a/src/token.js
+++ b/src/token.js
@@ -1,0 +1,10 @@
+import { InjectionKey } from "vue";
+import Sdk from "casdoor-js-sdk";
+
+const CASDOOR_SDK_TOKEN = '$casdoor-sdk';
+
+/**
+ * @summary  Injection token used to `provide` / `inject` the `Sdk` instance.
+ * @type { InjectionKey<Sdk> }
+ */
+export const CASDOOR_SDK_INJECTION_KEY = Symbol.for(CASDOOR_SDK_TOKEN);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,11 @@
+const path = require('path');
+
 module.exports = {
   entry: './index.js',
   mode: 'none',
+  resolve: {
+    alias: {
+      '@':  path.resolve(__dirname, 'src/')
+    }
+  }
 }


### PR DESCRIPTION
# Summary

Using `app.provide` to provide the instance of `Sdk` with key `CASDOOR_INJECTION_KEY`, then encapsulate `inject(CASDOOR_INJECTION_KEY)` into `useCasdoor`.

# Usage

```js
const { signin } = useCasdoor();
```

# Relating issue

Fix: https://github.com/casdoor/casdoor-vue-sdk/issues/9