### PR TITLE
fix: Duplicated plugins of 'semantic-release' leading the failure of CI/CD.

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,16 +18,9 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
     "@semantic-release/github",
     ["@semantic-release/npm", {
       "pkgRoot": "dist"
-    }],
-    ["@semantic-release/git", {
-      "assets": [
-        "package.json",
-        "LICENSE"
-      ]
     }]
   ]
 }


### PR DESCRIPTION
### Description
Remove duplicated and useless plugins in the `releaserc.json`.

### Motivation and Context
In PR#13, the plugin `@semantic-release/npm` was added to publish the converted product of sources, but the old one didn't remove.
Meanwhile, the plugin `@semantic-release/git` was useless and should be removed.

### How Has This Been Tested?
I have tested it with `yarn run semantic-release --dry-run` to confirm that there aren't duplicating `"@semantic-release/npm"` steps anymore. 

### Relating issue

Fix: https://github.com/casdoor/casdoor-vue-sdk/issues/14