### PR TITLE
fix: import the type InjectionKey from vue3 in jsdoc

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -1,10 +1,9 @@
-import { InjectionKey } from "vue";
 import Sdk from "casdoor-js-sdk";
 
 const CASDOOR_SDK_TOKEN = '$casdoor-sdk';
 
 /**
  * @summary  Injection token used to `provide` / `inject` the `Sdk` instance.
- * @type { InjectionKey<Sdk> }
+ * @type { import('vue').InjectionKey<Sdk> }
  */
 export const CASDOOR_SDK_INJECTION_KEY = Symbol.for(CASDOOR_SDK_TOKEN);


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-vue-sdk/issues/18