### PR TITLE
feat: generate .d.ts from js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "babel src --out-dir dist/src && babel index.js --out-dir dist/ && cp package.json dist/ && cp LICENSE dist/ && cp README.md dist/",
+    "build": "tsc && babel src --out-dir dist/src && babel index.js --out-dir dist/ && cp package.json dist/ && cp LICENSE dist/ && cp README.md dist/",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
@@ -41,6 +41,7 @@
     "eslint": "^7.32.0",
     "eslint-plugin-vue": "^8.0.3",
     "semantic-release": "^17.4.4",
+    "typescript": "^4.8.4",
     "vue": "^3.0.0",
     "webpack-cli": "^4.9.2"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  // Change this to match your project
+  "include": ["index.js","src/**/*"],
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "dist",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8887,6 +8887,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+
 uglify-js@^3.1.4:
   version "3.15.3"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.3.tgz#9aa82ca22419ba4c0137642ba0df800cb06e0471"


### PR DESCRIPTION
# Description
generate `.d.ts` files while building the package.
 
# Details
1. Add dependencies `typescript` to generate `.d.ts` files.
3. Add `tsconfig.json` and modify the `build` command.

# Test
I have tested it with `Vue3` and `Vue2` projects, and you can try this PR by installing the tarball:
https://we.tl/t-xnr27ei4GX